### PR TITLE
permit exclusion-only usage

### DIFF
--- a/lib/Devel/CheckOS.pm
+++ b/lib/Devel/CheckOS.pm
@@ -77,6 +77,7 @@ of OSes and OS families, eg ...
 
 sub os_is {
     my @targets = @_;
+    if (@targets == 0) { return 1 }
     my $rval = 0;
     foreach my $target (@targets) {
         die("Devel::CheckOS: $target isn't a legal OS name\n")


### PR DESCRIPTION
For my module, I only want to prevent attempts to build on MicrosoftWindows. I assume it builds everywhere else.
