### PR TITLE
Fix case for negative assertions only

### DIFF
--- a/lib/Devel/AssertOS.pm
+++ b/lib/Devel/AssertOS.pm
@@ -51,8 +51,8 @@ sub import {
         }
     }
 
-    Devel::CheckOS::die_if_os_is(@must_not);
-    Devel::CheckOS::die_if_os_isnt(@must);
+    Devel::CheckOS::die_if_os_is(@must_not) if @must_not;
+    Devel::CheckOS::die_if_os_isnt(@must)   if @must;
 }
 
 =head1 BUGS and FEEDBACK

--- a/t/62-assertos-do-not-want.t
+++ b/t/62-assertos-do-not-want.t
@@ -4,9 +4,22 @@ $^W = 1;
 use File::Spec;
 use lib File::Spec->catdir(qw(t lib));
 
-use Test::More tests => 1;
+use Test::More tests => 4;
+
+eval "use Devel::AssertOS qw/ -NotAnOperatingSystem /";
+
+is $@ => '', "do not want, not our OS, all is good";
 
 eval "use Devel::AssertOS qw/ -AnOperatingSystem /";
 
-like $@ => qr/OS unsupported/;
+like $@ => qr/OS unsupported/, "do not want our OS => dying";
 
+$@ = undef;
+
+eval "use Devel::AssertOS qw/ -NotAnOperatingSystem AnOperatingSystem /";
+
+is $@ => '', 'negative + positive assertions successful';
+
+eval "use Devel::AssertOS qw/ NotAnOperatingSystem -AnOperatingSystem /";
+
+like $@ => qr/OS unsupported/, 'negative + positive assertions failing';


### PR DESCRIPTION
If there is only negative assertions, the must_or_die() check
gets an empty array, and promptly die. Change the check to skip
the panic if there are no OSes passed. Also, beefed up the tests
to cover that case.
