### PR TITLE
Android support

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -91,3 +91,4 @@ lib/Devel/AssertOS/MacOSX/v10_5.pm
 lib/Devel/AssertOS/GNUkFreeBSD.pm
 t/62-assertos-do-not-want.t
 lib/Devel/AssertOS/Bitrig.pm
+lib/Devel/AssertOS/Android.pm

--- a/lib/Devel/AssertOS/Android.pm
+++ b/lib/Devel/AssertOS/Android.pm
@@ -1,0 +1,11 @@
+package Devel::AssertOS::Android;
+
+use Devel::CheckOS;
+
+$VERSION = '1.2';
+
+sub os_is { $^O =~ /^android$/i ? 1 : 0; }
+
+Devel::CheckOS::die_unsupported() unless(os_is());
+
+1;

--- a/lib/Devel/AssertOS/Linux.pm
+++ b/lib/Devel/AssertOS/Linux.pm
@@ -4,9 +4,19 @@ use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^linux$/i ? 1 : 0; }
+
+sub matches { qw(Linux Android) }
+sub os_is {
+    $^O =~ /^linux$/i
+    ? 1
+    : Devel::CheckOS::os_is(grep !/^linux$/i, matches());
+}
 
 Devel::CheckOS::die_unsupported() unless(os_is());
+
+sub expn {
+    "The operating system has a Linux kernel"
+}
 
 =head1 COPYRIGHT and LICENCE
 

--- a/lib/Devel/AssertOS/Unix.pm
+++ b/lib/Devel/AssertOS/Unix.pm
@@ -8,7 +8,7 @@ $VERSION = '1.5';
 #
 sub matches {
     return qw(
-        AIX Bitrig BSDOS DGUX DragonflyBSD Dynix FreeBSD HPUX Interix Irix
+        AIX Android Bitrig BSDOS DGUX DragonflyBSD Dynix FreeBSD HPUX Interix Irix
         Linux MachTen MacOSX MirOSBSD NetBSD OpenBSD OSF QNX SCO Solaris
         SunOS SysVr4 SysVr5 Unicos MidnightBSD
     );

--- a/t/16-expn.t
+++ b/t/16-expn.t
@@ -1,7 +1,7 @@
 use strict;
 $^W = 1;
 
-use Test::More tests => 21;
+use Test::More tests => 22;
 
 use Devel::CheckOS;
 

--- a/t/50-script.t
+++ b/t/50-script.t
@@ -1,7 +1,7 @@
 use strict;
 $^W = 1;
 
-use Test::More tests => 57;
+use Test::More tests => 58;
 use File::Temp;
 use File::Spec;
 use Devel::CheckOS;
@@ -101,7 +101,7 @@ sub checkCopyCorrectModulesLinux26MicrosoftWindows {
 	"inc/Devel/CheckOS.pm exists");
     is_deeply(
         [sort split("\n", _getfile(File::Spec->catfile($projectdir, 'MANIFEST')))],
-	[sort qw(
+	[sort qw( inc/Devel/AssertOS/Android.pm
 	    inc/Devel/AssertOS/Linux/v2_6.pm inc/Devel/AssertOS/Linux.pm
 	    inc/Devel/AssertOS/MSWin32.pm inc/Devel/AssertOS/Cygwin.pm
 	    inc/Devel/AssertOS/MicrosoftWindows.pm
@@ -154,7 +154,7 @@ wibblywobblywoo', # mmm, significant whitespace
     );
     is_deeply(
         [sort split("\n", _getfile(File::Spec->catfile($projectdir, 'MANIFEST')))],
-	[sort qw(
+	[sort qw( inc/Devel/AssertOS/Android.pm
 	    inc/Devel/AssertOS/Linux.pm inc/Devel/AssertOS/MSWin32.pm
 	    inc/Devel/CheckOS.pm inc/Devel/AssertOS.pm
 	    HLAGH
@@ -182,7 +182,7 @@ wibblywobblywoo', # mmm, significant whitespace
     );
     is_deeply(
         [sort split("\n", _getfile(File::Spec->catfile($projectdir, 'MANIFEST')))],
-	[sort qw(
+	[sort qw( inc/Devel/AssertOS/Android.pm
 	    inc/Devel/AssertOS/Linux.pm inc/Devel/AssertOS/MSWin32.pm
 	    inc/Devel/CheckOS.pm inc/Devel/AssertOS.pm
 	    HLAGH
@@ -205,7 +205,7 @@ sub emptydir {
     );
     is_deeply(
         [sort split("\n", _getfile(File::Spec->catfile($projectdir, 'MANIFEST')))],
-	[sort qw(
+	[sort qw( inc/Devel/AssertOS/Android.pm
 	    inc/Devel/AssertOS/Linux.pm inc/Devel/AssertOS/MSWin32.pm
 	    inc/Devel/CheckOS.pm inc/Devel/AssertOS.pm
 	    MANIFEST Makefile.PL

--- a/t/60-mockery.t
+++ b/t/60-mockery.t
@@ -4,11 +4,12 @@ $^W = 1;
 use File::Spec;
 use lib File::Spec->catdir(qw(t lib));
 
-use Test::More tests => 46;
+use Test::More tests => 49;
 
 my %platforms = (
     aix         => 'AIX',
     amigaos     => 'Amiga',
+    android     => 'Android',
     beos        => 'BeOS',
     bsdos       => 'BSDOS',
     cygwin      => 'Cygwin',
@@ -65,4 +66,10 @@ foreach my $o (sort { lc($platforms{$a}) cmp lc($platforms{$b}) }keys %platforms
 {
   local $^O = 'haiku';
   ok(Devel::CheckOS::os_is('BeOS'), "Haiku is also BeOS");
+}
+
+{
+    local $^O = 'android';
+    ok(Devel::CheckOS::os_is('Linux'), "Android is also Linux");
+    ok(Devel::CheckOS::os_is('Unix'), "Android is also Unix");
 }


### PR DESCRIPTION
This required modifying Linux.pm a bit, since Android is basically a barebones Linux, so both os_is('Unix') and os_is('Linux') need to return true for it.

Also, I should point out that currently the module installs cleanly on Android, which was very surprising; nothing seemed wrong until another module tried doing a os_is('Unix'), which returned false and sent me chasing down the dependency tree. Maybe the module should die at build time if it doesn't know the OS it's on?
