### PR TITLE
this module is kwalitee-aware, and explicitly rejects unwanted tests

### DIFF
--- a/t/63-kwalitee.t
+++ b/t/63-kwalitee.t
@@ -1,0 +1,13 @@
+use Test::More;
+
+use strict;
+use warnings;
+BEGIN {
+   plan skip_all => 'these tests are for release candidate testing'
+      unless $ENV{RELEASE_TESTING};
+}
+
+# no license is by design
+use Test::Kwalitee::Extra qw(:optional !meta_yml_has_license);
+
+done_testing;


### PR DESCRIPTION
add auto-kwalitee check, inform other CPAN Pull Challenge players / any other devs that the lack of license META info is by choice