### PR TITLE
Revert "use strict / use warnings"

### DIFF
--- a/lib/Devel/AssertOS.pm
+++ b/lib/Devel/AssertOS.pm
@@ -3,9 +3,13 @@ package Devel::AssertOS;
 use Devel::CheckOS;
 
 use strict;
-use warnings;
 
-our $VERSION = '1.21';
+use vars qw($VERSION);
+
+$VERSION = '1.21';
+
+# localising prevents the warningness leaking out of this module
+local $^W = 1;    # use warnings is a 5.6-ism
 
 =head1 NAME
 

--- a/lib/Devel/AssertOS/AIX.pm
+++ b/lib/Devel/AssertOS/AIX.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::AIX;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^aix$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Amiga.pm
+++ b/lib/Devel/AssertOS/Amiga.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Amiga;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^amigaos$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Android.pm
+++ b/lib/Devel/AssertOS/Android.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Android;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^android$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Apple.pm
+++ b/lib/Devel/AssertOS/Apple.pm
@@ -3,10 +3,8 @@
 package Devel::AssertOS::Apple;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub matches { return qw(MacOSX MacOSclassis); }
 sub os_is { Devel::CheckOS::os_is(matches()); }

--- a/lib/Devel/AssertOS/BSDOS.pm
+++ b/lib/Devel/AssertOS/BSDOS.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::BSDOS;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^bsdos$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/BeOS.pm
+++ b/lib/Devel/AssertOS/BeOS.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::BeOS;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.4';
+$VERSION = '1.4';
 
 # weird special case, not quite like other OS modules, as this is both
 # an OS *and* a family - maybe this should be fixed at some point

--- a/lib/Devel/AssertOS/Bitrig.pm
+++ b/lib/Devel/AssertOS/Bitrig.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Bitrig;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.0';
+$VERSION = '1.0';
 
 sub os_is { $^O =~ /^BITRIG$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Cygwin.pm
+++ b/lib/Devel/AssertOS/Cygwin.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Cygwin;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.3';
+$VERSION = '1.3';
 
 sub os_is { $^O =~ /^cygwin$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/DEC.pm
+++ b/lib/Devel/AssertOS/DEC.pm
@@ -3,10 +3,8 @@
 package Devel::AssertOS::DEC;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.4';
+$VERSION = '1.4';
 
 sub matches { return qw(OSF VMS); }
 sub os_is { Devel::CheckOS::os_is(matches()); }

--- a/lib/Devel/AssertOS/DGUX.pm
+++ b/lib/Devel/AssertOS/DGUX.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::DGUX;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^dgux$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/DragonflyBSD.pm
+++ b/lib/Devel/AssertOS/DragonflyBSD.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::DragonflyBSD;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^dragonfly$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Dynix.pm
+++ b/lib/Devel/AssertOS/Dynix.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Dynix;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^dynixptx$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/EBCDIC.pm
+++ b/lib/Devel/AssertOS/EBCDIC.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::EBCDIC;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.0';
+$VERSION = '1.0';
 
 # list of OSes lifted from Module::Build 0.2808
 #

--- a/lib/Devel/AssertOS/Extending.pod
+++ b/lib/Devel/AssertOS/Extending.pod
@@ -26,9 +26,7 @@ called Devel::AssertOS::PlatformName which looks like:
 
     package Devel::AssertOS::Linux;
     use Devel::CheckOS;
-    use strict;
-    use warnings;
-    our $VERSION = '1.0';
+    $VERSION = '1.0';
     sub os_is { $^O =~ /^linux$/i ? 1 : 0; }
     Devel::CheckOS::die_unsupported() unless(os_is());
     1;
@@ -56,9 +54,7 @@ match any of several values of C<$^O> like this:
 
     package Devel::AssertOS::FreeSoftware;
     use Devel::CheckOS;
-    use strict;
-    use warnings;
-    our $VERSION = '1.0';
+    $VERSION = '1.0';
     sub matches { return qw(Linux FreeBSD NetBSD OpenBSD DragonflyBSD); }
     sub os_is { Devel::CheckOS::os_is(matches()); }
     sub expn { "The operating system is free-as-in-beer" }

--- a/lib/Devel/AssertOS/FreeBSD.pm
+++ b/lib/Devel/AssertOS/FreeBSD.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::FreeBSD;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^(gnuk)?freebsd$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/GNUkFreeBSD.pm
+++ b/lib/Devel/AssertOS/GNUkFreeBSD.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::GNUkFreeBSD;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.1';
+$VERSION = '1.1';
 
 sub os_is { $^O =~ /^gnukfreebsd$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/HPUX.pm
+++ b/lib/Devel/AssertOS/HPUX.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::HPUX;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^hpux$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Haiku.pm
+++ b/lib/Devel/AssertOS/Haiku.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Haiku;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.1';
+$VERSION = '1.1';
 
 sub os_is { $^O =~ /^haiku$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Interix.pm
+++ b/lib/Devel/AssertOS/Interix.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Interix;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^interix$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Irix.pm
+++ b/lib/Devel/AssertOS/Irix.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Irix;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^irix$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Linux.pm
+++ b/lib/Devel/AssertOS/Linux.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Linux;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.3';
+$VERSION = '1.3';
 
 
 sub subtypes { qw(Android) }

--- a/lib/Devel/AssertOS/Linux/Debian.pm
+++ b/lib/Devel/AssertOS/Linux/Debian.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::Linux::Debian;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/Linux/v2_6.pm
+++ b/lib/Devel/AssertOS/Linux/v2_6.pm
@@ -3,10 +3,8 @@
 package Devel::AssertOS::Linux::v2_6;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.3';
+$VERSION = '1.3';
 
 sub os_is {
     Devel::CheckOS::os_is('Linux') &&

--- a/lib/Devel/AssertOS/MPEiX.pm
+++ b/lib/Devel/AssertOS/MPEiX.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::MPEiX;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^mpeix$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/MSDOS.pm
+++ b/lib/Devel/AssertOS/MSDOS.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::MSDOS;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^dos$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/MSWin32.pm
+++ b/lib/Devel/AssertOS/MSWin32.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::MSWin32;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.3';
+$VERSION = '1.3';
 
 sub os_is { $^O =~ /^MSWin32$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/MacOSX.pm
+++ b/lib/Devel/AssertOS/MacOSX.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::MacOSX;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^darwin$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/MacOSX/v10_0.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_0.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_0;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_1.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_1.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_1;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_10.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_10.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_10;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_2.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_2.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_2;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_3.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_3.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_3;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_4.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_4.pm
@@ -4,7 +4,6 @@ package Devel::AssertOS::MacOSX::v10_4;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.4';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_5.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_5.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_5;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_6.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_6.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_6;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_7.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_7.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_7;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_8.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_8.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_8;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSX/v10_9.pm
+++ b/lib/Devel/AssertOS/MacOSX/v10_9.pm
@@ -2,7 +2,6 @@ package Devel::AssertOS::MacOSX::v10_9;
 
 use Devel::CheckOS;
 use strict;
-use warnings;
 
 our $VERSION = '1.0';
 

--- a/lib/Devel/AssertOS/MacOSclassic.pm
+++ b/lib/Devel/AssertOS/MacOSclassic.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::MacOSclassic;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^MacOS$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/MachTen.pm
+++ b/lib/Devel/AssertOS/MachTen.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::MachTen;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^machten$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/MicrosoftWindows.pm
+++ b/lib/Devel/AssertOS/MicrosoftWindows.pm
@@ -3,10 +3,8 @@
 package Devel::AssertOS::MicrosoftWindows;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.3';
+$VERSION = '1.3';
 
 sub matches { return qw(Cygwin MSWin32); }
 sub os_is { Devel::CheckOS::os_is(matches()); }

--- a/lib/Devel/AssertOS/MidnightBSD.pm
+++ b/lib/Devel/AssertOS/MidnightBSD.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::MidnightBSD;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.1';
+$VERSION = '1.1';
 
 sub os_is { $^O =~ /^midnightbsd$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/MirOSBSD.pm
+++ b/lib/Devel/AssertOS/MirOSBSD.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::MirOSBSD;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^mirbsd$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/NeXT.pm
+++ b/lib/Devel/AssertOS/NeXT.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::NeXT;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^next$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/NetBSD.pm
+++ b/lib/Devel/AssertOS/NetBSD.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::NetBSD;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^netbsd$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Netware.pm
+++ b/lib/Devel/AssertOS/Netware.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Netware;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^netware$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/OS2.pm
+++ b/lib/Devel/AssertOS/OS2.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::OS2;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.1';
+$VERSION = '1.1';
 
 sub os_is { $^O =~ /^os2$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/OS390.pm
+++ b/lib/Devel/AssertOS/OS390.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::OS390;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^os390$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/OS400.pm
+++ b/lib/Devel/AssertOS/OS400.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::OS400;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^os400$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/OSF.pm
+++ b/lib/Devel/AssertOS/OSF.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::OSF;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^dec_osf$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/OSFeatures/POSIXShellRedirection.pm
+++ b/lib/Devel/AssertOS/OSFeatures/POSIXShellRedirection.pm
@@ -2,11 +2,9 @@
 
 package Devel::AssertOS::OSFeatures::POSIXShellRedirection;
 
-our $VERSION = '1.4';
+$VERSION = '1.4';
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
 sub matches { return qw(Unix Cygwin BeOS VOS); }
 sub os_is { Devel::CheckOS::os_is(matches()); }

--- a/lib/Devel/AssertOS/OpenBSD.pm
+++ b/lib/Devel/AssertOS/OpenBSD.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::OpenBSD;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/POSIXBC.pm
+++ b/lib/Devel/AssertOS/POSIXBC.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::POSIXBC;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^posix-bc$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/QNX.pm
+++ b/lib/Devel/AssertOS/QNX.pm
@@ -3,10 +3,8 @@
 package Devel::AssertOS::QNX;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub matches { return qw(QNX::v4 QNX::Neutrino); }
 sub os_is { Devel::CheckOS::os_is(matches()); }

--- a/lib/Devel/AssertOS/QNX/Neutrino.pm
+++ b/lib/Devel/AssertOS/QNX/Neutrino.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::QNX::Neutrino;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.1';
+$VERSION = '1.1';
 
 sub os_is { $^O =~ /^nto$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/QNX/v4.pm
+++ b/lib/Devel/AssertOS/QNX/v4.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::QNX::v4;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.1';
+$VERSION = '1.1';
 
 sub os_is { $^O =~ /^qnx$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/RISCOS.pm
+++ b/lib/Devel/AssertOS/RISCOS.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::RISCOS;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^riscos$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Realtime.pm
+++ b/lib/Devel/AssertOS/Realtime.pm
@@ -3,10 +3,8 @@
 package Devel::AssertOS::Realtime;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub matches { return qw(QNX); }
 sub os_is { Devel::CheckOS::os_is(matches()); }

--- a/lib/Devel/AssertOS/SCO.pm
+++ b/lib/Devel/AssertOS/SCO.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::SCO;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^sco_sv$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Solaris.pm
+++ b/lib/Devel/AssertOS/Solaris.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Solaris;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^solaris$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Sun.pm
+++ b/lib/Devel/AssertOS/Sun.pm
@@ -3,10 +3,8 @@
 package Devel::AssertOS::Sun;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.3';
+$VERSION = '1.3';
 
 sub matches { return qw(SunOS Solaris); }
 sub os_is { Devel::CheckOS::os_is(matches()); }

--- a/lib/Devel/AssertOS/SunOS.pm
+++ b/lib/Devel/AssertOS/SunOS.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::SunOS;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^sunos$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/SysVr4.pm
+++ b/lib/Devel/AssertOS/SysVr4.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::SysVr4;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^svr4$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/SysVr5.pm
+++ b/lib/Devel/AssertOS/SysVr5.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::SysVr5;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^svr5$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Unicos.pm
+++ b/lib/Devel/AssertOS/Unicos.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Unicos;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^unicos(mk)?$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/Unix.pm
+++ b/lib/Devel/AssertOS/Unix.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::Unix;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.5';
+$VERSION = '1.5';
 
 # list of OSes originally lifted from Module::Build 0.2808
 #

--- a/lib/Devel/AssertOS/VMESA.pm
+++ b/lib/Devel/AssertOS/VMESA.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::VMESA;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^vmesa$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/VMS.pm
+++ b/lib/Devel/AssertOS/VMS.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::VMS;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^VMS$/i ? 1 : 0; }
 

--- a/lib/Devel/AssertOS/VOS.pm
+++ b/lib/Devel/AssertOS/VOS.pm
@@ -1,10 +1,8 @@
 package Devel::AssertOS::VOS;
 
 use Devel::CheckOS;
-use strict;
-use warnings;
 
-our $VERSION = '1.2';
+$VERSION = '1.2';
 
 sub os_is { $^O =~ /^vos$/i ? 1 : 0; }
 

--- a/lib/Devel/CheckOS.pm
+++ b/lib/Devel/CheckOS.pm
@@ -1,12 +1,14 @@
 package Devel::CheckOS;
 
 use strict;
-use warnings;
 use Exporter;
 
-use vars qw(@ISA @EXPORT_OK %EXPORT_TAGS);
+use vars qw($VERSION @ISA @EXPORT_OK %EXPORT_TAGS);
 
-our $VERSION = '1.74';
+$VERSION = '1.74';
+
+# localising prevents the warningness leaking out of this module
+local $^W = 1;    # use warnings is a 5.6-ism
 
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(os_is os_isnt die_if_os_is die_if_os_isnt die_unsupported list_platforms list_family_members);


### PR DESCRIPTION
Reverts DrHyde/perl-modules-Devel-CheckOS#11

The causes a load of warnings from ```AUTOMATED_TESTING=1 perl Makefile.PL```