### PR TITLE
Restore 5.6 and 5.8 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ t/XX-*
 MYMETA.json
 MYMETA.yml
 Makefile
+Makefile.old
 blib/
 pm_to_blib

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ perl:
   - "blead"   # builds perl from git
 matrix:
   include:
-    - perl: 5.20
+    - perl: "5.20"
       env: COVERAGE=1
   allow_failures:
     - perl: blead

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,14 @@ perl:
   - "5.22"
   - "5.24"
   - "5.26"
+  - "dev"     # latest point release
+  - "blead"   # builds perl from git
 matrix:
   include:
     - perl: 5.20
       env: COVERAGE=1
+  allow_failures:
+    - perl: blead
 before_install:
   - eval $(curl https://travis-perl.github.io/init) --auto
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: perl
 env: PERL_USE_UNSAFE_INC=0
 perl:
+  - "5.8"
   - "5.10"
   - "5.12"
   - "5.14"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.81    ...             Restore 5.6 and 5.8 compatibility
+
 1.80    2017-05-24      Fix bug where tests would fail if
                           AUTOMATED_TESTING=1 on perl 5.26 and higher;
                         For some reason that made it break on 5.8.9,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,10 +1,10 @@
-require 5.010;
+require 5.006;
 use ExtUtils::MakeMaker;
 
 use File::Spec;
 
 use strict;
-local $^W = 1;
+use warnings;
 
 use lib 'lib';
 

--- a/lib/Devel/CheckOS.pm
+++ b/lib/Devel/CheckOS.pm
@@ -33,13 +33,6 @@ like Linux, Solaris, AIX etc.
 It spares perl the embarrassment of wearing its pants on its head by
 covering them with a splendid Fedora.
 
-=head1 INCOMPATIBILITY WARNING
-
-Version 1.80 and higher only work on perl 5.10 and higher. I have no
-idea why it's broken on 5.8.9 (the lowest version I was previously
-testing on). If you care about perls that ancient I welcome a patch
-to restore functionality.
-
 =head1 SYNOPSIS
 
     use Devel::CheckOS qw(os_is);


### PR DESCRIPTION
I tested this locally and on travis and all seems to be okay.  But even if there are failures, at least the user gets a chance to figure out what's wrong.  (And I'd be happy to look into any future failures as they come up.)

This allows Catalyst::Devel to install on 5.8 again, which unblocks the current Catalyst release cycle.

I also tweaked the travis config a bit.