### PR TITLE
check os_is rather than just assert to detect OSs in AUTOMATED_TESTING

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -88,8 +88,9 @@ sub findOSes {
         my $modname = join('::', File::Spec->splitdir($dir), $_);
         (my $classname = $modname) =~ s/^lib:://;
         (my $prompt_modname = $modname) =~ s/.*AssertOS:://;
-        eval "use $classname";
-        next if($@);
+        if (!eval "use $classname; ${classname}::os_is()") {
+            next;
+        }
         my $hasexpn = $classname->can('expn') ? '/?' : '';
    ASK: my $answer = prompt(
             "Are you using $prompt_modname? [Y/n$hasexpn]",


### PR DESCRIPTION
When AUTOMATED_TESTING is set, additional tests are enabled.  These are
generated by checking what assert modules load properly.  However, on
perl 5.8, loading an assert module a second time will appear to succeed.
So we need to check os_is in addition to just loading the module.