### PR TITLE
Makefile.PL: Fix LICENSE spec

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -61,12 +61,12 @@ if($ENV{AUTOMATED_TESTING}) {
 WriteMakefile(
     NAME         => 'Devel::CheckOS',
     META_MERGE => {
-        license => 'open_source',
         resources => {
             repository => 'https://github.com/DrHyde/perl-modules-Devel-CheckOS',
             bugtracker => 'https://github.com/DrHyde/perl-modules-Devel-CheckOS/issues'
         },
     },
+    LICENSE      => 'perl',
     MIN_PERL_VERSION => "5.6.0",
     VERSION_FROM => 'lib/Devel/CheckOS.pm',
     CONFIGURE_REQUIRES => {


### PR DESCRIPTION
`META_MERGE` leaves the `"unknown"` in the META file. Also, GPL+Artistic+Artistic2.0 should be specified as "perl" or "perl_5", meaning "the same as Perl 5".