### PR TITLE
Makefile.PL: Fix LICENSE spec

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -61,12 +61,13 @@ if($ENV{AUTOMATED_TESTING}) {
 WriteMakefile(
     NAME         => 'Devel::CheckOS',
     META_MERGE => {
-        license => 'open_source',
+        license => ["artistic_1", "artistic_2"],
         resources => {
             repository => 'https://github.com/DrHyde/perl-modules-Devel-CheckOS',
             bugtracker => 'https://github.com/DrHyde/perl-modules-Devel-CheckOS/issues'
         },
     },
+    LICENSE      => "gpl_2",
     MIN_PERL_VERSION => "5.6.0",
     VERSION_FROM => 'lib/Devel/CheckOS.pm',
     CONFIGURE_REQUIRES => {


### PR DESCRIPTION
META_MERGE leaves the `"unknown"` in the META file. Also, GPL+Artistic+Artistic2.0 should be specified as `["gpl_2", "artistic_1", "artistic_2"]`. So, tell MakeMaker that the license is `"gpl_2"` and then append Artistic v1/v2 with META_MERGE.

See #45 