### PR TITLE
OS ID's are not always \w+

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.03	2024-05-??
+
+- OS ID's are not always \w+
+
 2.02    2024-05-15
 
 - Read /etc/os-release to detect Ubuntu instead of shelling out to `lsb_release`

--- a/lib/Devel/AssertOS/OSFeatures/Release.pm
+++ b/lib/Devel/AssertOS/OSFeatures/Release.pm
@@ -54,7 +54,7 @@ specified above.
 sub distributor_id {
     my $filename  = 'os-release';
     my $file_path = File::Spec->catfile( ( '', 'etc' ), $filename );
-    my $regex     = qr/^ID\=(\w+)/;
+    my $regex     = qr/^ID=(['"]?)([-\w.]+)\1\s*$/;
     my $dist_id   = undef;
 
     if ( -r $file_path ) {
@@ -62,7 +62,7 @@ sub distributor_id {
         while (<$in>) {
             chomp;
             if ( $_ =~ $regex ) {
-                $dist_id = ucfirst(lc $1) if (defined($1));
+                $dist_id = ucfirst(lc $2) if (defined($2));
                 last;
             }
         }

--- a/t/os-release.t
+++ b/t/os-release.t
@@ -12,7 +12,7 @@ SKIP: {
     my $id = distributor_id();
     ok( $id, 'can fetch the distribution ID' )
       or BAIL_OUT('No use to keep testing with ID = undef');
-    like $id, qr/^\w+$/, 'ID looks like a string';
+    like $id, qr/^[-\w.]+$/, 'ID looks like a string';
     my $copy = ucfirst( lc $id );
     is( $id, $copy, 'ID is returned with first character in uppercase' );
 }


### PR DESCRIPTION
```
🐧 cat /etc/os-release
NAME="openSUSE Leap"
VERSION="15.5"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="15.5"
PRETTY_NAME="openSUSE Leap 15.5"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:15.5"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
LOGO="distributor-logo-Leap"
```